### PR TITLE
GC_LOG_BACKUP变量赋值问题修复.

### DIFF
--- a/vjstar/src/main/script/jvm-options/jvm-options.sh
+++ b/vjstar/src/main/script/jvm-options/jvm-options.sh
@@ -83,7 +83,7 @@ fi
 
 
 if [ -f ${GC_LOG_FILE} ]; then
-  GC_LOG_BACKUP =  ${LOGDIR}/gc-${APPID}-$(date +'%Y%m%d_%H%M%S').log
+  GC_LOG_BACKUP=${LOGDIR}/gc-${APPID}-$(date +'%Y%m%d_%H%M%S').log
   echo "saving gc log ${GC_LOG_FILE} to ${GC_LOG_BACKUP}"
   mv ${GC_LOG_FILE} ${GC_LOG_BACKUP}
 fi


### PR DESCRIPTION
```
 GC_LOG_BACKUP: command not found
saving gc log /dev/shm/gc-app.log to
mv: missing destination file operand after ‘/dev/shm/gc-app.log’
```
shell变量赋值为空
