### PR TITLE
[vjtop] print all block threads via dump all threads

### DIFF
--- a/vjtop/src/main/java/com/vip/vjtools/vjtop/InteractiveTask.java
+++ b/vjtop/src/main/java/com/vip/vjtools/vjtop/InteractiveTask.java
@@ -56,6 +56,8 @@ public class InteractiveTask implements Runnable {
 			printTopStack();
 		} else if (command.equals("a")) {
 			displayAllThreads();
+		} else if (command.equals("b")) {
+			displayBlockedThreads();
 		} else if (command.equals("m")) {
 			changeDisplayMode();
 		} else if (command.equals("i") || command.startsWith("i ")) {
@@ -115,6 +117,17 @@ public class InteractiveTask implements Runnable {
 			app.continueFlush();
 		}
 	}
+
+	private void displayBlockedThreads() throws IOException {
+		try {
+			app.preventFlush();
+			app.view.printBlockedThreads();
+			waitForEnter();
+		} finally {
+			app.continueFlush();
+		}
+	}
+
 
 	private void changeDisplayMode() {
 		app.preventFlush();
@@ -216,6 +229,7 @@ public class InteractiveTask implements Runnable {
 		tty.println(" t [tid]: print stack trace of the thread you choose");
 		tty.println(" s : print stack trace of top " + app.view.threadLimit + " threads");
 		tty.println(" a : list id and name of all threads");
+		tty.println(" b : list id and name of all blocked threads");
 		tty.println(" m : change threads display mode and ordering");
 		tty.println(" i [num]: change flush interval seconds");
 		tty.println(" l [num]: change number of display threads");

--- a/vjtop/src/main/java/com/vip/vjtools/vjtop/VMDetailView.java
+++ b/vjtop/src/main/java/com/vip/vjtools/vjtop/VMDetailView.java
@@ -503,7 +503,7 @@ public class VMDetailView {
 	 * 打印所有线程，只获取名称不获取stack，不造成停顿
 	 */
 	public void printAllThreads() throws IOException {
-		System.out.println(System.lineSeparator() + " Thread Id and name for all live threads:");
+		System.out.println(System.lineSeparator() + " Thread Id and name of all live threads:");
 
 		long tids[] = vmInfo.getAllThreadIds();
 		ThreadInfo[] threadInfos = vmInfo.getThreadInfo(tids);
@@ -525,6 +525,32 @@ public class VMDetailView {
 		}
 		System.out.flush();
 	}
+
+	public void printBlockedThreads() throws IOException {
+		System.out.println(System.lineSeparator() + " Thread Id and name of all blocked threads:");
+
+		ThreadInfo[] threadInfos = vmInfo.getBlockedThreadInfo();
+		for (ThreadInfo info : threadInfos) {
+			if (info == null) {
+				continue;
+			}
+
+			String threadName = info.getThreadName();
+			// I think thread state check could reduce filter check, so I check state first. Robin @ 2018.9.18
+			if (!Thread.State.BLOCKED.equals(info.getThreadState()) ||
+					(threadNameFilter != null && !threadName.toLowerCase().contains(threadNameFilter))) {
+				continue;
+			}
+			System.out.println(
+					" " + info.getThreadId() + "\t: \"" + threadName + "\" (" + info.getThreadState().toString() + ")");
+		}
+
+		if (threadNameFilter != null) {
+			System.out.println(" Thread name filter is:" + threadNameFilter);
+		}
+		System.out.flush();
+	}
+
 
 	public void switchCpuAndMemory() {
 		topThreadInfo.cleanupThreadsHistory();

--- a/vjtop/src/main/java/com/vip/vjtools/vjtop/VMInfo.java
+++ b/vjtop/src/main/java/com/vip/vjtools/vjtop/VMInfo.java
@@ -429,6 +429,14 @@ public class VMInfo {
 		return jmxClient.getThreadMXBean().getThreadAllocatedBytes(tids);
 	}
 
+	public ThreadInfo[] getBlockedThreadInfo() throws IOException {
+		return jmxClient.getThreadMXBean().dumpAllThreads(false, false);
+	}
+
+	public ThreadInfo[] getBlockedThreadInfo(boolean lockedMonitors, boolean lockedSynchronizers) throws IOException {
+		return jmxClient.getThreadMXBean().dumpAllThreads(lockedMonitors, lockedSynchronizers);
+	}
+
 	private void initPerfCounters(Map<String, Counter> perfCounters) {
 		threadLiveCounter = (LongCounter) perfCounters.get("java.threads.live");
 		threadDaemonCounter = (LongCounter) perfCounters.get("java.threads.daemon");


### PR DESCRIPTION
这是 issue #119 的实现，参照了打印所有线程的代码
具体效果：
help option:
~~~sh
 Input command (h for help):h
 t [tid]: print stack trace of the thread you choose
 s : print stack trace of top 10 threads
 a : list id and name of all threads
 b : list id and name of all blocked threads
 m : change threads display mode and ordering
 i [num]: change flush interval seconds
 l [num]: change number of display threads
 f [name]: set thread name filter
 q : quit
 h : print help
~~~

b option:
~~~sh
 Input command (h for help):b

 Thread Id and name of all blocked threads:
 10	: "Thread-1" (BLOCKED)
 9	: "Thread-0" (BLOCKED)
~~~

jstack 查到的 blocked 线程数：
~~~sh
jstack -l 21302 | grep -ci blocked
2
~~~