### PR TITLE
添加记录运行时间以便效率分析的工具PerformanceUtils

### DIFF
--- a/vjkit/src/main/java/com/vip/vjtools/vjkit/logging/PerformanceUtils.java
+++ b/vjkit/src/main/java/com/vip/vjtools/vjkit/logging/PerformanceUtils.java
@@ -1,0 +1,220 @@
+package com.vip.vjtools.vjkit.logging;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+
+/**
+ * 效率管理工具
+ * @author william.liang
+ *
+ */
+public class PerformanceUtils {
+	private PerformanceUtils() {
+	}
+
+	private static ThreadLocal<Timer> localTimer = new ThreadLocal<>();
+	private static ThreadLocal<Map<String, Timer>> localTimerMap = new ThreadLocal<>();
+
+	/**
+	 * 记录开始时间
+	 */
+	public static void start() {
+		getTimer().start();
+	}
+
+	/**
+	 * 记录结束时间
+	 */
+	public static void end() {
+		getTimer().end();
+	}
+
+	/**
+	 * 计算耗时
+	 * @return
+	 */
+	public static long duration() {
+		return getTimer().duration();
+	}
+
+	/**
+	 * 清除ThreadLocal
+	 */
+	public static void remove() {
+		localTimer.remove();
+		localTimerMap.remove();
+	}
+
+	/**
+	 * 记录开始时间
+	 * @param key
+	 */
+	public static void start(String key) {
+		getTimer(key).start();
+	}
+
+	/**
+	 * 记录结束时间
+	 * @param key
+	 */
+	public static void end(String key) {
+		getTimer(key).end();
+	}
+
+	/**
+	 * 计算耗时
+	 * @param key
+	 * @return
+	 */
+	public static long duration(String key) {
+		return getTimer(key).duration();
+	}
+
+	/**
+	 * 清除ThreadLocal
+	 * @param key
+	 */
+	public static void remove(String key) {
+		getTimerMap().remove(key);
+	}
+
+	/**
+	 * 当处理时间超过预定的阈值时发出警告信息
+	 * @param log
+	 * @param threshold 阈值（单位：ms）
+	 */
+	public static void warn(Logger log, long threshold) {
+		if (duration() > threshold) {
+			log.warn("[Performance Warning] json= msg=任务处理时长超过设定的阈值，总时长为{}ms", duration());
+		}
+	}
+
+	/**
+	 * 当处理时间超过预定的阈值时发出警告信息
+	 * @param log
+	 * @param key
+	 * @param threshold 阈值（单位：ms）
+	 */
+	public static void warn(Logger log, String key, long threshold) {
+		if (duration(key) > threshold) {
+			log.warn("[Performance Warning] json= msg=任务【{}】处理时长超过设定的阈值，总时长为{}ms", key, duration(key));
+		}
+	}
+
+	/**
+	 * 当处理时间超过预定的阈值时发出警告信息
+	 * @param log
+	 * @param threshold 阈值（单位：ms）
+	 * @param json 需要记录的对象json
+	 */
+	public static void warn(Logger log, long threshold, String json) {
+		if (duration() > threshold) {
+			log.warn("[Performance Warning] json={} msg=任务处理时长超过设定的阈值，总时长为{}ms", json, duration());
+		}
+	}
+
+	/**
+	 * 当处理时间超过预定的阈值时发出警告信息
+	 * @param log
+	 * @param key
+	 * @param threshold 阈值（单位：ms）
+	 * @param json 需要记录的对象json
+	 */
+	public static void warn(Logger log, String key, long threshold, String json) {
+		if (duration(key) > threshold) {
+			log.warn("[Performance Warning] json={} msg=任务【{}】处理时长超过设定的阈值，总时长为{}ms", json, key, duration(key));
+		}
+	}
+
+	/**
+	 * 记录结束时间并当处理时间超过预定的阈值时发出警告信息，最后清除
+	 * @param log
+	 * @param threshold 阈值（单位：ms）
+	 */
+	public static void endWithWarnAndRemove(Logger log, long threshold) {
+		end();
+		warn(log, threshold);
+		remove();
+	}
+
+	/**
+	 * 记录结束时间并当处理时间超过预定的阈值时发出警告信息，最后清除
+	 * @param log
+	 * @param key
+	 * @param threshold 阈值（单位：ms）
+	 */
+	public static void endWithWarnAndRemove(Logger log, String key, long threshold) {
+		end(key);
+		warn(log, key, threshold);
+		remove(key);
+	}
+
+	/**
+	 * 记录结束时间并当处理时间超过预定的阈值时发出警告信息，最后清除
+	 * @param log
+	 * @param threshold 阈值（单位：ms）
+	 * @param json 需要记录的对象json
+	 */
+	public static void endWithWarnAndRemove(Logger log, long threshold, String json) {
+		end();
+		warn(log, threshold, json);
+		remove();
+	}
+
+	/**
+	 * 记录结束时间并当处理时间超过预定的阈值时发出警告信息，最后清除
+	 * @param log
+	 * @param key
+	 * @param threshold 阈值（单位：ms）
+	 * @param json 需要记录的对象json
+	 */
+	public static void endWithWarnAndRemove(Logger log, String key, long threshold, String json) {
+		end(key);
+		warn(log, key, threshold, json);
+		remove(key);
+	}
+
+	private static Timer getTimer(String key) {
+		Timer timer = getTimerMap().getOrDefault(key, new Timer());
+		getTimerMap().putIfAbsent(key, timer);
+		return timer;
+	}
+
+	private static Timer getTimer() {
+		Timer timer = localTimer.get();
+		if (timer == null) {
+			timer = new Timer();
+			localTimer.set(timer);
+		}
+		return timer;
+	}
+
+	private static Map<String, Timer> getTimerMap() {
+		Map<String, Timer> timerMap = localTimerMap.get();
+		if (timerMap == null) {
+			timerMap = new HashMap<>(16);
+			localTimerMap.set(timerMap);
+		}
+		return timerMap;
+	}
+
+	static class Timer {
+		private long start;
+		private long end;
+
+		public void start() {
+			start = System.currentTimeMillis();
+		}
+
+		public void end() {
+			end = System.currentTimeMillis();
+		}
+
+		public long duration() {
+			return end - start;
+		}
+	}
+
+}

--- a/vjkit/src/test/java/com/vip/vjtools/vjkit/logging/PerformanceUtilsTest.java
+++ b/vjkit/src/test/java/com/vip/vjtools/vjkit/logging/PerformanceUtilsTest.java
@@ -1,0 +1,25 @@
+package com.vip.vjtools.vjkit.logging;
+
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+
+public class PerformanceUtilsTest {
+	
+	Logger logger = (Logger) LoggerFactory.getLogger(PerformanceUtilsTest.class);
+
+	@Test
+	public void test() throws InterruptedException {
+		PerformanceUtils.start();
+		PerformanceUtils.start("test");
+		Thread.sleep(1000L);// NOSONAR
+		System.out.println(Thread.currentThread().getName() + " time cost: " + PerformanceUtils.duration() + "ms");
+		PerformanceUtils.end();
+		PerformanceUtils.warn(logger, 0L);
+		PerformanceUtils.end("test");
+		System.out.println(Thread.currentThread().getName() + " time cost: " + PerformanceUtils.duration() + "ms");
+		PerformanceUtils.warn(logger, "test", 0L);
+	}
+	
+}


### PR DESCRIPTION
多线程中记录任意两个代码点间的耗时，在不需要aop的情况下，可以使用该工具，比如A类中执行A,B,C上个方法，A方法中有一个步骤a1，需要记录从它开始做，到B方法中步骤b2的耗时，按业务逻辑又无法独立为独立方法以便切面时。