### PR TITLE
if the log dir does not exist, create it first to avoid subsequent l…

### DIFF
--- a/vjstar/src/main/script/jvm-options/jvm-options.sh
+++ b/vjstar/src/main/script/jvm-options/jvm-options.sh
@@ -76,13 +76,15 @@ GC_OPTS="$GC_OPTS -XX:+UnlockDiagnosticVMOptions -XX:ParGCCardsPerStrideChunk=10
 
 # 默认使用/dev/shm 内存文件系统避免在高IO场景下写GC日志时被阻塞导致STW时间延长
 if [ -d /dev/shm/ ]; then
-    GC_LOG_FILE=/dev/shm/gc-${APPID}.log
+  GC_LOG_FILE=/dev/shm/gc-${APPID}.log
 else
-	GC_LOG_FILE=${LOGDIR}/gc-${APPID}.log
+  GC_LOG_FILE=${LOGDIR}/gc-${APPID}.log
 fi
 
 
 if [ -f ${GC_LOG_FILE} ]; then
+  [ ! -d ${LOGDIR} ] && mkdir -p ${LOGDIR}
+
   GC_LOG_BACKUP=${LOGDIR}/gc-${APPID}-$(date +'%Y%m%d_%H%M%S').log
   echo "saving gc log ${GC_LOG_FILE} to ${GC_LOG_BACKUP}"
   mv ${GC_LOG_FILE} ${GC_LOG_BACKUP}
@@ -94,7 +96,7 @@ GCLOG_OPTS="-Xloggc:${GC_LOG_FILE} -XX:+PrintGCDetails -XX:+PrintGCDateStamps -X
 
 #打印GC原因，JDK8默认打开
 if [[ "$JAVA_VERSION" < "1.8" ]]; then
-	GCLOG_OPTS="$GCLOG_OPTS -XX:+PrintGCCause"
+  GCLOG_OPTS="$GCLOG_OPTS -XX:+PrintGCCause"
 fi
 
 


### PR DESCRIPTION
When the log dir `LOGDIR` does not exist, call jvm-options.sh will got:
```shell
mv: cannot create regular file './logs/gc-myapp-20200311_211323.log': No such file or directory
```

We can create it first to avoid subsequent log file copy failue when the log dir does not exist.

Some script formats have been adjusted to keep their styles consistent.