### PR TITLE
fix(sec): upgrade jackson-databind to 2.12.6.1

### DIFF
--- a/vjkit/pom.xml
+++ b/vjkit/pom.xml
@@ -14,7 +14,7 @@
 		<slf4j.version>1.7.25</slf4j.version>
 		<logback.version>1.1.11</logback.version>
 		<dozer.version>5.5.1</dozer.version>
-		<jackson.version>2.9.10.4</jackson.version>
+		<jackson.version>2.12.6.1</jackson.version>
 		<junit.version>4.12</junit.version>
 		<assertj.version>2.6.0</assertj.version>
 		<mockito.version>2.18.3</mockito.version>


### PR DESCRIPTION
Upgrade jackson-databind from 2.9.10.4 to 2.12.6.1 for vulnerability fix:
- [CVE-2020-24616](https://www.oscs1024.com/hd/MPS-2020-11987)
- [CVE-2020-24750](https://www.oscs1024.com/hd/MPS-2020-13151)
- [CVE-2020-36518](https://www.oscs1024.com/hd/MPS-2022-6242)