### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.12.6.1

### DIFF
--- a/vjkit/pom.xml
+++ b/vjkit/pom.xml
@@ -14,7 +14,7 @@
 		<slf4j.version>1.7.25</slf4j.version>
 		<logback.version>1.1.11</logback.version>
 		<dozer.version>5.5.1</dozer.version>
-		<jackson.version>2.9.10.4</jackson.version>
+		<jackson.version>2.12.6.1</jackson.version>
 		<junit.version>4.12</junit.version>
 		<assertj.version>2.6.0</assertj.version>
 		<mockito.version>2.18.3</mockito.version>


### PR DESCRIPTION
### What happened？
There are 21 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.9.10.4
- [CVE-2020-24616](https://www.oscs1024.com/hd/CVE-2020-24616)
- [CVE-2020-24750](https://www.oscs1024.com/hd/CVE-2020-24750)
- [CVE-2020-35490](https://www.oscs1024.com/hd/CVE-2020-35490)
- [CVE-2020-35491](https://www.oscs1024.com/hd/CVE-2020-35491)
- [CVE-2020-35728](https://www.oscs1024.com/hd/CVE-2020-35728)
- [CVE-2020-14061](https://www.oscs1024.com/hd/CVE-2020-14061)
- [CVE-2020-14062](https://www.oscs1024.com/hd/CVE-2020-14062)
- [CVE-2020-14060](https://www.oscs1024.com/hd/CVE-2020-14060)
- [CVE-2020-14195](https://www.oscs1024.com/hd/CVE-2020-14195)
- [CVE-2020-36179](https://www.oscs1024.com/hd/CVE-2020-36179)
- [CVE-2020-36180](https://www.oscs1024.com/hd/CVE-2020-36180)
- [CVE-2020-36182](https://www.oscs1024.com/hd/CVE-2020-36182)
- [CVE-2020-36183](https://www.oscs1024.com/hd/CVE-2020-36183)
- [CVE-2020-36184](https://www.oscs1024.com/hd/CVE-2020-36184)
- [CVE-2020-36185](https://www.oscs1024.com/hd/CVE-2020-36185)
- [CVE-2020-36186](https://www.oscs1024.com/hd/CVE-2020-36186)
- [CVE-2020-36187](https://www.oscs1024.com/hd/CVE-2020-36187)
- [CVE-2020-36188](https://www.oscs1024.com/hd/CVE-2020-36188)
- [CVE-2020-36189](https://www.oscs1024.com/hd/CVE-2020-36189)
- [CVE-2021-20190](https://www.oscs1024.com/hd/CVE-2021-20190)
- [CVE-2020-36518](https://www.oscs1024.com/hd/CVE-2020-36518)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.9.10.4 to 2.12.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS