### PR TITLE
fix(sec): upgrade com.google.code.gson:gson to 2.8.9

### DIFF
--- a/standard/sonar-vj/pom.xml
+++ b/standard/sonar-vj/pom.xml
@@ -12,7 +12,7 @@
 		<sonar.version>6.7.1</sonar.version>
 		<java.plugin.version>5.0.1.12818</java.plugin.version>
 		<sslr.version>1.21</sslr.version>
-		<gson.version>2.6.2</gson.version>
+		<gson.version>2.8.9</gson.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.code.gson:gson 2.6.2
- [CVE-2022-25647](https://www.oscs1024.com/hd/CVE-2022-25647)


### What did I do？
Upgrade com.google.code.gson:gson from 2.6.2 to 2.8.9 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS